### PR TITLE
Convert to plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,3 @@
 composer.phar
 /vendor/
-
-# Commit your application's lock file https://getcomposer.org/doc/01-basic-usage.md#commit-your-composer-lock-file-to-version-control
-# You may choose to ignore a library lock file http://getcomposer.org/doc/02-libraries.md#lock-file
-# composer.lock
+composer.lock

--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
 # generate-deployment-identifier
+
+```
+$ composer dump-deployment-identifier
+1f5daba-0f7bfc3ca48bc647bf9f5cb20e7436c472d58403⏎
+```
+
+## Dump the value into the file
+```
+composer dump-deployment-identifier > .VERSION
+```

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,20 @@
 {
     "name": "nymedia/generate-deployment-identifier",
     "description": "Generate a unique enough deployment identifier",
+    "type": "composer-plugin",
     "require": {
-        "eiriksm/gitinfo": "^2.0||^3.0||^4.0"
+        "eiriksm/gitinfo": "^2.0||^3.0||^4.0",
+        "composer-plugin-api": "^2.0"
+    },
+    "require-dev": {
+        "composer/composer": "^2.0"
+    },
+    "autoload": {
+        "psr-4": {
+            "Nymedia\\GenerateDeploymentIdentifier\\": "src/"
+        }
+    },
+    "extra": {
+        "class": "Nymediaas\\GenerateDeploymentIdentifier\\Plugin"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,6 @@
         }
     },
     "extra": {
-        "class": "Nymediaas\\GenerateDeploymentIdentifier\\Plugin"
+        "class": "Nymedia\\GenerateDeploymentIdentifier\\Plugin"
     }
 }

--- a/src/CommandProvider.php
+++ b/src/CommandProvider.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Nymedia\GenerateDeploymentIdentifier;
+
+use Composer\Plugin\Capability\CommandProvider as CommandProviderCapability;
+
+class CommandProvider implements CommandProviderCapability
+{
+
+  /**
+   * {@inheritDoc}
+   */
+  public function getCommands()
+  {
+    return array(new Dumper());
+  }
+}

--- a/src/Dumper.php
+++ b/src/Dumper.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Nymedia\GenerateDeploymentIdentifier;
+
+use Composer\Command\BaseCommand;
+use Composer\InstalledVersions;
+use eiriksm\GitInfo\GitInfo;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class Dumper extends BaseCommand {
+
+  /**
+   * {@inheritDoc}
+   */
+  protected function configure()
+  {
+    $this->setName('dump-deployment-identifier');
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  protected function execute(InputInterface $input, OutputInterface $output)
+  {
+    $gitInfo = new GitInfo();
+    $installed = hash('sha1', json_encode(InstalledVersions::getAllRawData()));
+    $output->write($gitInfo->getShortHash() . '-' . $installed);
+  }
+
+}

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Nymedia\GenerateDeploymentIdentifier;
+
+use Composer\Composer;
+use Composer\IO\IOInterface;
+use Composer\Plugin\Capable;
+use Composer\Plugin\PluginInterface;
+
+class Plugin implements PluginInterface, Capable
+{
+
+  /**
+   * {@inheritDoc}
+   */
+  public function activate(Composer $composer, IOInterface $io)
+  {
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function deactivate(Composer $composer, IOInterface $io)
+  {
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function uninstall(Composer $composer, IOInterface $io)
+  {
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function getCapabilities()
+  {
+    return array(
+      'Composer\Plugin\Capability\CommandProvider' => 'Nymedia\GenerateDeploymentIdentifier\CommandProvider',
+    );
+  }
+}


### PR DESCRIPTION
This is now a composer plugin and it is [capable](https://getcomposer.org/doc/articles/plugins.md#plugin-capabilities) of exposing a custom command - `composer dump-deployment-identifier` which will output current git (short) sha and hash of all installed composer dependencies.